### PR TITLE
Camera class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,8 @@ set(TEST_SOURCES
   tests/test_Point.cpp
   tests/test_Intersection.cpp
   tests/test_Ray.cpp
+  tests/test_Rectangle.cpp
+  tests/test_Camera.cpp
 )
 
 set(IMPLEMENTATION_SOURCES ${SOURCES})

--- a/src/Core/Camera.hpp
+++ b/src/Core/Camera.hpp
@@ -17,22 +17,25 @@ class Camera {
 public:
   /**
    * @brief Default constructor initializes the camera at the origin with a
-   * default screen.
+   * default screen and field of view.
    */
   Camera()
       : m_origin(Math::Point<3>(0.0, 0.0, 0.0)),
         m_screen(Math::Rectangle3D(Math::Point<3>(0.0, 0.0, 1.0),
                                    Math::Vector<3>(1.0, 0.0, 0.0),
-                                   Math::Vector<3>(0.0, 1.0, 0.0))) {}
+                                   Math::Vector<3>(0.0, 1.0, 0.0))),
+        m_fov(90.0 * M_PI / 180.0) {}
 
   /**
    * @brief Constructor that initializes the camera with a given origin and
    * screen.
    * @param origin The origin of the camera.
    * @param screen The screen of the camera.
+   * @param fov The field of view of the camera (in radians).
    */
-  Camera(const Math::Point<3> &origin, const Math::Rectangle3D &screen)
-      : m_origin(origin), m_screen(screen) {}
+  Camera(const Math::Point<3> &origin, const Math::Rectangle3D &screen,
+         double fov)
+      : m_origin(origin), m_screen(screen), m_fov(fov) {}
 
   /**
    * @brief Default destructor for the Camera class.
@@ -105,6 +108,32 @@ public:
   void setScreen(const Math::Rectangle3D &screen) { m_screen = screen; }
 
   /**
+   * @brief Get the field of view of the camera.
+   * @return The field of view of the camera (in radians).
+   */
+  [[nodiscard]] double getFov() const { return m_fov; }
+
+  /**
+   * @brief Set the field of view of the camera.
+   * @param fov The new field of view of the camera (in radians).
+   */
+  void setFov(double fov) { m_fov = fov; }
+
+  /**
+   * @brief Set the perspective of the camera based on the aspect ratio.
+   * @param aspectRatio The aspect ratio of the screen.
+   */
+  void setPerspective(double aspectRatio) {
+    double newHeight = 2.0 * std::tan(m_fov / 2.0);
+    double newWidth = aspectRatio * newHeight;
+
+    m_screen =
+        Math::Rectangle3D(Math::Point<3>(-newWidth / 2, -newHeight / 2, 1.0),
+                          Math::Vector<3>(newWidth, 0.0, 0.0),
+                          Math::Vector<3>(0.0, newHeight, 0.0));
+  }
+
+  /**
    * @brief Generate a ray from the camera to a point on the screen.
    * @param u The u coordinate on the screen (0.0 to 1.0).
    * @param v The v coordinate on the screen (0.0 to 1.0).
@@ -123,6 +152,7 @@ public:
 private:
   Math::Point<3> m_origin;
   Math::Rectangle3D m_screen;
+  double m_fov;
 };
 
 } // namespace Raytracer::Core

--- a/src/Core/Camera.hpp
+++ b/src/Core/Camera.hpp
@@ -9,26 +9,56 @@
 
 namespace Raytracer::Core {
 
+/**
+ * @class Camera
+ * @brief A class representing a camera in 3D space.
+ */
 class Camera {
 public:
+  /**
+   * @brief Default constructor initializes the camera at the origin with a
+   * default screen.
+   */
   Camera()
       : m_origin(Math::Point<3>(0.0, 0.0, 0.0)),
         m_screen(Math::Rectangle3D(Math::Point<3>(0.0, 0.0, 1.0),
                                    Math::Vector<3>(1.0, 0.0, 0.0),
                                    Math::Vector<3>(0.0, 1.0, 0.0))) {}
 
+  /**
+   * @brief Constructor that initializes the camera with a given origin and
+   * screen.
+   * @param origin The origin of the camera.
+   * @param screen The screen of the camera.
+   */
   Camera(const Math::Point<3> &origin, const Math::Rectangle3D &screen)
       : m_origin(origin), m_screen(screen) {}
 
+  /**
+   * @brief Default destructor for the Camera class.
+   */
   ~Camera() = default;
 
+  /**
+   * @brief Copy constructor.
+   * @param other The camera to copy from.
+   */
   Camera(const Camera &other)
       : m_origin(other.m_origin), m_screen(other.m_screen) {}
 
+  /**
+   * @brief Move constructor.
+   * @param other The camera to move from.
+   */
   Camera(Camera &&other) noexcept
       : m_origin(std::move(other.m_origin)),
         m_screen(std::move(other.m_screen)) {}
 
+  /**
+   * @brief Copy assignment operator.
+   * @param other The camera to copy from.
+   * @return A reference to the current camera.
+   */
   Camera &operator=(const Camera &other) {
     if (this != &other) {
       m_origin = other.m_origin;
@@ -37,6 +67,11 @@ public:
     return *this;
   }
 
+  /**
+   * @brief Move assignment operator.
+   * @param other The camera to move from.
+   * @return A reference to the current camera.
+   */
   Camera &operator=(Camera &&other) noexcept {
     if (this != &other) {
       m_origin = std::move(other.m_origin);
@@ -45,13 +80,45 @@ public:
     return *this;
   }
 
+  /**
+   * @brief Get the origin of the camera.
+   * @return The origin of the camera.
+   */
   [[nodiscard]] const Math::Point<3> &getOrigin() const { return m_origin; }
 
+  /**
+   * @brief Get the screen of the camera.
+   * @return The screen of the camera.
+   */
   [[nodiscard]] const Math::Rectangle3D &getScreen() const { return m_screen; }
 
+  /**
+   * @brief Set the origin of the camera.
+   * @param origin The new origin of the camera.
+   */
   void setOrigin(const Math::Point<3> &origin) { m_origin = origin; }
 
+  /**
+   * @brief Set the screen of the camera.
+   * @param screen The new screen of the camera.
+   */
   void setScreen(const Math::Rectangle3D &screen) { m_screen = screen; }
+
+  /**
+   * @brief Generate a ray from the camera to a point on the screen.
+   * @param u The u coordinate on the screen (0.0 to 1.0).
+   * @param v The v coordinate on the screen (0.0 to 1.0).
+   * @return A ray from the camera to the specified point on the screen.
+   */
+  [[nodiscard]] Core::Ray ray(Utility::Clamped<double, 0.0, 1.0> u,
+                              Utility::Clamped<double, 0.0, 1.0> v) const {
+    Math::Point<3> screenPoint = m_screen.pointAt(u, v);
+    Math::Vector<3> direction = screenPoint - m_origin;
+
+    direction.normalize();
+
+    return Core::Ray(m_origin, direction);
+  }
 
 private:
   Math::Point<3> m_origin;

--- a/src/Core/Camera.hpp
+++ b/src/Core/Camera.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "Core/Ray.hpp"
+#include "Math/Point.hpp"
+#include "Math/Rectangle.hpp"
+#include "Math/Vector.hpp"
+#include "Utility/Clamped.hpp"
+#include <cmath>
+
+namespace Raytracer::Core {
+
+class Camera {
+public:
+  Camera()
+      : m_origin(Math::Point<3>(0.0, 0.0, 0.0)),
+        m_screen(Math::Rectangle3D(Math::Point<3>(0.0, 0.0, 1.0),
+                                   Math::Vector<3>(1.0, 0.0, 0.0),
+                                   Math::Vector<3>(0.0, 1.0, 0.0))) {}
+
+  Camera(const Math::Point<3> &origin, const Math::Rectangle3D &screen)
+      : m_origin(origin), m_screen(screen) {}
+
+  ~Camera() = default;
+
+  Camera(const Camera &other)
+      : m_origin(other.m_origin), m_screen(other.m_screen) {}
+
+  Camera(Camera &&other) noexcept
+      : m_origin(std::move(other.m_origin)),
+        m_screen(std::move(other.m_screen)) {}
+
+  Camera &operator=(const Camera &other) {
+    if (this != &other) {
+      m_origin = other.m_origin;
+      m_screen = other.m_screen;
+    }
+    return *this;
+  }
+
+  Camera &operator=(Camera &&other) noexcept {
+    if (this != &other) {
+      m_origin = std::move(other.m_origin);
+      m_screen = std::move(other.m_screen);
+    }
+    return *this;
+  }
+
+  [[nodiscard]] const Math::Point<3> &getOrigin() const { return m_origin; }
+
+  [[nodiscard]] const Math::Rectangle3D &getScreen() const { return m_screen; }
+
+  void setOrigin(const Math::Point<3> &origin) { m_origin = origin; }
+
+  void setScreen(const Math::Rectangle3D &screen) { m_screen = screen; }
+
+private:
+  Math::Point<3> m_origin;
+  Math::Rectangle3D m_screen;
+};
+
+} // namespace Raytracer::Core

--- a/src/Core/Camera.hpp
+++ b/src/Core/Camera.hpp
@@ -47,7 +47,8 @@ public:
    * @param other The camera to copy from.
    */
   Camera(const Camera &other)
-      : m_origin(other.m_origin), m_screen(other.m_screen) {}
+      : m_origin(other.m_origin), m_screen(other.m_screen), m_fov(other.m_fov) {
+  }
 
   /**
    * @brief Move constructor.
@@ -55,7 +56,7 @@ public:
    */
   Camera(Camera &&other) noexcept
       : m_origin(std::move(other.m_origin)),
-        m_screen(std::move(other.m_screen)) {}
+        m_screen(std::move(other.m_screen)), m_fov(other.m_fov) {}
 
   /**
    * @brief Copy assignment operator.
@@ -66,6 +67,7 @@ public:
     if (this != &other) {
       m_origin = other.m_origin;
       m_screen = other.m_screen;
+      m_fov = other.m_fov;
     }
     return *this;
   }
@@ -79,6 +81,7 @@ public:
     if (this != &other) {
       m_origin = std::move(other.m_origin);
       m_screen = std::move(other.m_screen);
+      m_fov = other.m_fov;
     }
     return *this;
   }
@@ -140,14 +143,7 @@ public:
    * @return A ray from the camera to the specified point on the screen.
    */
   [[nodiscard]] Core::Ray ray(Utility::Clamped<double, 0.0, 1.0> u,
-                              Utility::Clamped<double, 0.0, 1.0> v) const {
-    Math::Point<3> screenPoint = m_screen.pointAt(u, v);
-    Math::Vector<3> direction = screenPoint - m_origin;
-
-    direction.normalize();
-
-    return Core::Ray(m_origin, direction);
-  }
+                              Utility::Clamped<double, 0.0, 1.0> v) const;
 
 private:
   Math::Point<3> m_origin;

--- a/src/Math/Point.hpp
+++ b/src/Math/Point.hpp
@@ -37,6 +37,11 @@ public:
   }
 
   /**
+   * @brief Default destructor for the Point class.
+   */
+  ~Point() noexcept = default;
+
+  /**
    * @brief Adding a point and a vector.
    * @param vec The vector to add.
    * @return A new point that is the sum of the point and the vector.

--- a/src/Math/Rectangle.hpp
+++ b/src/Math/Rectangle.hpp
@@ -1,0 +1,163 @@
+/**
+ * @file Point.hpp
+ * @brief Defines the Point class template for representing mathematical
+ * points.
+ */
+
+#pragma once
+
+#include "Point.hpp"
+#include "Utility/Clamped.hpp"
+#include "Vector.hpp"
+#include <cmath>
+namespace Raytracer::Math {
+
+/**
+ * @class Rectangle
+ * @brief A class template representing a rectangle in N dimensional space.
+ * @tparam N The dimension of the rectangle.
+ */
+template <std::size_t N> class Rectangle {
+public:
+  using PointN = Point<N>;
+  using VectorN = Vector<N>;
+
+  /**
+   * @brief Default constructor initializes the rectangle with default values.
+   */
+  Rectangle() = default;
+
+  /**
+   * @brief Constructor that initializes the rectangle with the given origin,
+   * bottom side, and left side.
+   * @param origin The origin of the rectangle.
+   * @param bottomSide The vector representing the bottom side of the rectangle.
+   * @param leftSide The vector representing the left side of the rectangle.
+   */
+  Rectangle(const PointN &origin, const VectorN &bottomSide,
+            const VectorN &leftSide)
+      : m_origin(origin), m_bottomSide(bottomSide), m_leftSide(leftSide) {}
+
+  /**
+   * @brief Default destructor for the Rectangle class.
+   */
+  virtual ~Rectangle() noexcept = default;
+
+  /**
+   * @brief Get the origin of the rectangle.
+   * @return The origin of the rectangle.
+   */
+  [[nodiscard]] const PointN &getOrigin() const { return m_origin; }
+
+  /**
+   * @brief Get the bottom side of the rectangle.
+   * @return The vector representing the bottom side of the rectangle.
+   */
+  [[nodiscard]] const VectorN &getBottomSide() const { return m_bottomSide; }
+
+  /**
+   * @brief Get the left side of the rectangle.
+   * @return The vector representing the left side of the rectangle.
+   */
+  [[nodiscard]] const VectorN &getLeftSide() const { return m_leftSide; }
+
+  /**
+   * @brief Set the origin of the rectangle.
+   * @param newOrigin The new origin of the rectangle.
+   */
+  void setOrigin(const PointN &newOrigin) { m_origin = newOrigin; }
+
+  /**
+   * @brief Set the bottom side of the rectangle.
+   * @param newBottomSide The new vector representing the bottom side of the
+   * rectangle.
+   */
+  void setBottomSide(const VectorN &newBottomSide) {
+    m_bottomSide = newBottomSide;
+  }
+
+  /**
+   * @brief Set the left side of the rectangle.
+   * @param newLeftSide The new vector representing the left side of the
+   * rectangle.
+   */
+  void setLeftSide(const VectorN &newLeftSide) { m_leftSide = newLeftSide; }
+
+protected:
+  PointN m_origin{};
+  VectorN m_bottomSide{};
+  VectorN m_leftSide{};
+};
+
+/**
+ * @class Rectangle3D
+ * @brief A class representing a rectangle in 3D space.
+ */
+class Rectangle3D : public Rectangle<3> {
+public:
+  using Point3D = Point<3>;
+  using Vector3D = Vector<3>;
+
+  /**
+   * @brief Default constructor initializes the rectangle with default values.
+   */
+  Rectangle3D() : Rectangle<3>() {}
+
+  /**
+   * @brief Constructor that initializes the rectangle with the given origin,
+   * bottom side, and left side.
+   * @param origin The origin of the rectangle.
+   * @param bottomSide The vector representing the bottom side of the rectangle.
+   * @param leftSide The vector representing the left side of the rectangle.
+   */
+  Rectangle3D(const Point3D &origin, const Vector3D &bottomSide,
+              const Vector3D &leftSide)
+      : Rectangle<3>(origin, bottomSide, leftSide) {}
+
+  /**
+   * @brief Default destructor for the Rectangle3D class.
+   */
+  ~Rectangle3D() noexcept override = default;
+
+  /**
+   * @brief Get the point at the given u and v coordinates on the rectangle.
+   * @param u The u coordinate (0.0 to 1.0).
+   * @param v The v coordinate (0.0 to 1.0).
+   * @return The point at the given u and v coordinates on the rectangle.
+   */
+  [[nodiscard]] Point3D pointAt(Utility::Clamped<double, 0.0, 1.0> u,
+                                Utility::Clamped<double, 0.0, 1.0> v) const {
+    return m_origin + (m_bottomSide * u) + (m_bottomSide * v);
+  }
+
+  /**
+   * @brief Get the normal vector of the rectangle.
+   * @return The normal vector of the rectangle.
+   */
+  [[nodiscard]] Vector3D getNormal() const {
+    return m_bottomSide.cross(m_leftSide).normalize();
+  }
+
+  /**
+   * @brief Get the area of the rectangle.
+   * @return The area of the rectangle.
+   */
+  [[nodiscard]] double getArea() const {
+    return m_bottomSide.cross(m_leftSide).length();
+  }
+
+  /**
+   * @brief Check if the given point is inside the rectangle.
+   * @param point The point to check.
+   * @return True if the point is inside the rectangle, false otherwise.
+   */
+  [[nodiscard]] bool contains(const Point3D &point) const {
+    Vector3D p = point - m_origin;
+
+    double u = p.dot(m_bottomSide) / m_bottomSide.dot(m_bottomSide);
+    double v = p.dot(m_leftSide) / m_leftSide.dot(m_leftSide);
+
+    return u >= 0.0 && u <= 1.0 && v >= 0.0 && v <= 1.0;
+  }
+};
+} // namespace Raytracer::Math

--- a/src/Math/Rectangle.hpp
+++ b/src/Math/Rectangle.hpp
@@ -127,7 +127,7 @@ public:
    */
   [[nodiscard]] Point3D pointAt(Utility::Clamped<double, 0.0, 1.0> u,
                                 Utility::Clamped<double, 0.0, 1.0> v) const {
-    return m_origin + (m_bottomSide * u) + (m_bottomSide * v);
+    return m_origin + (m_bottomSide * u) + (m_leftSide * v);
   }
 
   /**

--- a/src/Math/Rectangle.hpp
+++ b/src/Math/Rectangle.hpp
@@ -127,7 +127,7 @@ public:
    */
   [[nodiscard]] Point3D pointAt(Utility::Clamped<double, 0.0, 1.0> u,
                                 Utility::Clamped<double, 0.0, 1.0> v) const {
-    return m_origin + (m_bottomSide * u) + (m_leftSide * v);
+    return m_origin + (m_bottomSide * u.get()) + (m_leftSide * v.get());
   }
 
   /**

--- a/src/Math/Vector.hpp
+++ b/src/Math/Vector.hpp
@@ -9,7 +9,10 @@
 #include <array>
 #include <cmath>
 #include <cstddef>
+
 namespace Raytracer::Math {
+
+template <std::size_t N> class Point;
 
 /**
  * @class Vector
@@ -291,4 +294,21 @@ private:
     setComponents(index + 1, args...);
   }
 };
+
+/**
+ * @brief Subtracting two points.
+ * @param lhs The left-hand side point.
+ * @param rhs The right-hand side point.
+ * @return A new vector that is the difference of the two points.
+ */
+template <std::size_t N>
+[[nodiscard]] Vector<N> operator-(const Point<N> &lhs, const Point<N> &rhs) {
+  Vector<N> result;
+
+  for (std::size_t i = 0; i < N; ++i) {
+    result.m_components[i] = lhs.m_components[i] - rhs.m_components[i];
+  }
+
+  return result;
+}
 } // namespace Raytracer::Math

--- a/src/Math/Vector.hpp
+++ b/src/Math/Vector.hpp
@@ -37,6 +37,11 @@ public:
   }
 
   /**
+   * @brief Default destructor for the Vector class.
+   */
+  ~Vector() noexcept = default;
+
+  /**
    * @brief Get the length of the vector.
    * @return The length of the vector.
    */
@@ -231,6 +236,40 @@ public:
     }
 
     return result;
+  }
+
+  /**
+   * @brief Normalize the vector.
+   * @return A new vector that is the normalized version of the current vector.
+   */
+  Vector<N> normalize() const {
+    double len = length();
+    if (len == 0.0) {
+      return *this;
+    }
+
+    Vector<N> result;
+
+    for (std::size_t i = 0; i < N; ++i) {
+      result.m_components[i] = m_components[i] / len;
+    }
+
+    return result;
+  }
+
+  /**
+   * @brief Calculate the cross product of two 3D vectors.
+   * @param other The vector to calculate the cross product with.
+   * @return A new vector that is the cross product of the two vectors.
+   */
+  Vector<N> cross(const Vector<N> &other) const {
+    static_assert(N == 3, "Cross product is only defined for 3D vectors");
+    return Vector<N>(m_components[1] * other.m_components[2] -
+                         m_components[2] * other.m_components[1],
+                     m_components[2] * other.m_components[0] -
+                         m_components[0] * other.m_components[2],
+                     m_components[0] * other.m_components[1] -
+                         m_components[1] * other.m_components[0]);
   }
 
 private:

--- a/tests/test_Camera.cpp
+++ b/tests/test_Camera.cpp
@@ -1,0 +1,209 @@
+#include "../src/Core/Camera.hpp"
+#include "../src/Core/Ray.hpp"
+#include "../src/Math/Point.hpp"
+#include "../src/Math/Rectangle.hpp"
+#include "../src/Math/Vector.hpp"
+#include <cmath>
+#include <criterion/criterion.h>
+
+using Raytracer::Core::Camera;
+using Raytracer::Core::Ray;
+using Raytracer::Math::Point;
+using Raytracer::Math::Rectangle3D;
+using Raytracer::Math::Vector;
+
+static constexpr double EQ_APPROX = 1e-9;
+
+template <std::size_t N>
+void assert_point_eq(const Point<N> &p, const std::array<double, N> &ref,
+                     double eps = EQ_APPROX) {
+  for (std::size_t i = 0; i < N; ++i) {
+    cr_assert_float_eq(p.m_components[i], ref[i], eps,
+                       "Point component[%zu]: expected %g but got %g", i,
+                       ref[i], p.m_components[i]);
+  }
+}
+
+template <std::size_t N>
+void assert_vector_eq(const Vector<N> &v, const std::array<double, N> &ref,
+                      double eps = EQ_APPROX) {
+  for (std::size_t i = 0; i < N; ++i) {
+    cr_assert_float_eq(v.m_components[i], ref[i], eps,
+                       "Vector component[%zu]: expected %g but got %g", i,
+                       ref[i], v.m_components[i]);
+  }
+}
+
+void assert_rectangle_eq(const Rectangle3D &rectangle,
+                         const Point<3> &expectedOrigin,
+                         const Vector<3> &expectedBottomSide,
+                         const Vector<3> &expectedLeftSide,
+                         double eps = EQ_APPROX) {
+  assert_point_eq(rectangle.getOrigin(),
+                  {expectedOrigin.m_components[0],
+                   expectedOrigin.m_components[1],
+                   expectedOrigin.m_components[2]},
+                  eps);
+  assert_vector_eq(rectangle.getBottomSide(),
+                   {expectedBottomSide.m_components[0],
+                    expectedBottomSide.m_components[1],
+                    expectedBottomSide.m_components[2]},
+                   eps);
+  assert_vector_eq(rectangle.getLeftSide(),
+                   {expectedLeftSide.m_components[0],
+                    expectedLeftSide.m_components[1],
+                    expectedLeftSide.m_components[2]},
+                   eps);
+}
+
+void assert_ray_eq(const Ray &ray, const Point<3> &expectedOrigin,
+                   const Vector<3> &expectedDirection, double eps = EQ_APPROX) {
+  assert_point_eq(ray.getOrigin(),
+                  {expectedOrigin.m_components[0],
+                   expectedOrigin.m_components[1],
+                   expectedOrigin.m_components[2]},
+                  eps);
+  assert_vector_eq(ray.getDirection(),
+                   {expectedDirection.m_components[0],
+                    expectedDirection.m_components[1],
+                    expectedDirection.m_components[2]},
+                   eps);
+  cr_assert_float_eq(ray.getDirection().length(), 1.0, eps,
+                     "Ray direction should be normalized (length 1.0), got %g",
+                     ray.getDirection().length());
+}
+
+Test(CameraSuite, DefaultConstructor) {
+  Camera camera;
+
+  assert_point_eq(camera.getOrigin(), {0.0, 0.0, 0.0});
+
+  cr_assert_float_eq(camera.getFov(), M_PI / 2.0, EQ_APPROX,
+                     "Expected default FOV %g, got %g", M_PI / 2.0,
+                     camera.getFov());
+
+  Point<3> expectedScreenOrigin(0.0, 0.0, 1.0);
+  Vector<3> expectedScreenBottomSide(1.0, 0.0, 0.0);
+  Vector<3> expectedScreenLeftSide(0.0, 1.0, 0.0);
+  assert_rectangle_eq(camera.getScreen(), expectedScreenOrigin,
+                      expectedScreenBottomSide, expectedScreenLeftSide);
+}
+
+Test(CameraSuite, ParameterizedConstructor) {
+  Point<3> origin(1.0, 2.0, -1.0);
+  Point<3> screenOrigin(0.0, 0.0, 1.0);
+  Vector<3> screenBottomSide(1.6, 0.0, 0.0);
+  Vector<3> screenLeftSide(0.0, 0.9, 0.0);
+  Rectangle3D screen(screenOrigin, screenBottomSide, screenLeftSide);
+  double fov = 60.0 * M_PI / 180.0;
+
+  Camera camera(origin, screen, fov);
+
+  assert_point_eq(camera.getOrigin(), {1.0, 2.0, -1.0});
+  assert_rectangle_eq(camera.getScreen(), screenOrigin, screenBottomSide,
+                      screenLeftSide);
+  cr_assert_float_eq(camera.getFov(), fov, EQ_APPROX, "Expected FOV %g, got %g",
+                     fov, camera.getFov());
+}
+
+Test(CameraSuite, CopyConstructor) {
+  Point<3> origin(1.0, 2.0, -1.0);
+  Point<3> screenOrigin(0.0, 0.0, 1.0);
+  Vector<3> screenBottomSide(1.0, 0.0, 0.0);
+  Vector<3> screenLeftSide(0.0, 1.0, 0.0);
+  Rectangle3D screen(screenOrigin, screenBottomSide, screenLeftSide);
+  double fov = M_PI / 3.0;
+  Camera original(origin, screen, fov);
+  Camera copy(original);
+
+  assert_point_eq(copy.getOrigin(), {1.0, 2.0, -1.0});
+  assert_rectangle_eq(copy.getScreen(), screenOrigin, screenBottomSide,
+                      screenLeftSide);
+  cr_assert_float_eq(copy.getFov(), fov, EQ_APPROX);
+
+  original.setOrigin(Point<3>(5.0, 5.0, 5.0));
+  original.setFov(M_PI / 4.0);
+  original.setScreen(Rectangle3D(Point<3>(1.0, 1.0, 2.0),
+                                 Vector<3>(2.0, 0.0, 0.0),
+                                 Vector<3>(0.0, 2.0, 0.0)));
+
+  assert_point_eq(copy.getOrigin(), {1.0, 2.0, -1.0});
+  assert_rectangle_eq(copy.getScreen(), screenOrigin, screenBottomSide,
+                      screenLeftSide);
+  cr_assert_float_eq(copy.getFov(), fov, EQ_APPROX);
+}
+
+Test(CameraSuite, CopyAssignment) {
+  Point<3> origin1(1.0, 1.0, 1.0);
+  Point<3> screenOrigin1(0.0, 0.0, 1.0);
+  Vector<3> screenBottomSide1(1.0, 0.0, 0.0);
+  Vector<3> screenLeftSide1(0.0, 1.0, 0.0);
+  Rectangle3D screen1(screenOrigin1, screenBottomSide1, screenLeftSide1);
+  double fov1 = M_PI / 2.0;
+  Camera camera1(origin1, screen1, fov1);
+
+  Point<3> origin2(2.0, 2.0, 2.0);
+  Point<3> screenOrigin2(0.0, 0.0, 2.0);
+  Vector<3> screenBottomSide2(2.0, 0.0, 0.0);
+  Vector<3> screenLeftSide2(0.0, 2.0, 0.0);
+  Rectangle3D screen2(screenOrigin2, screenBottomSide2, screenLeftSide2);
+  double fov2 = M_PI / 3.0;
+  Camera camera2(origin2, screen2, fov2);
+
+  camera2 = camera1;
+
+  assert_point_eq(camera2.getOrigin(), {1.0, 1.0, 1.0});
+  assert_rectangle_eq(camera2.getScreen(), screenOrigin1, screenBottomSide1,
+                      screenLeftSide1);
+  cr_assert_float_eq(camera2.getFov(), fov1, EQ_APPROX);
+
+  camera1.setOrigin(Point<3>(5.0, 5.0, 5.0));
+  camera1.setScreen(Rectangle3D(Point<3>(5.0, 5.0, 5.0),
+                                Vector<3>(5.0, 0.0, 0.0),
+                                Vector<3>(0.0, 5.0, 0.0)));
+  assert_point_eq(camera2.getOrigin(), {1.0, 1.0, 1.0});
+  assert_rectangle_eq(camera2.getScreen(), screenOrigin1, screenBottomSide1,
+                      screenLeftSide1);
+}
+
+Test(CameraSuite, GettersAndSetters) {
+  Camera camera;
+
+  Point<3> newOrigin(10.0, -5.0, 2.0);
+  camera.setOrigin(newOrigin);
+  assert_point_eq(camera.getOrigin(), {10.0, -5.0, 2.0});
+
+  Point<3> screenOrigin(1.0, 1.0, 5.0);
+  Vector<3> screenBottomSide(2.0, 0.0, 0.0);
+  Vector<3> screenLeftSide(0.0, 1.0, 0.0);
+  Rectangle3D newScreen(screenOrigin, screenBottomSide, screenLeftSide);
+  camera.setScreen(newScreen);
+  assert_rectangle_eq(camera.getScreen(), screenOrigin, screenBottomSide,
+                      screenLeftSide);
+
+  double newFov = 45.0 * M_PI / 180.0;
+  camera.setFov(newFov);
+
+  cr_assert_float_eq(camera.getFov(), newFov, EQ_APPROX);
+}
+
+Test(CameraSuite, SetPerspective) {
+  Camera camera;
+  camera.setFov(60.0 * M_PI / 180.0);
+
+  double aspectRatio = 16.0 / 9.0;
+
+  camera.setPerspective(aspectRatio);
+
+  double expectedHeight = 2.0 / std::sqrt(3.0);
+  double expectedWidth = aspectRatio * expectedHeight;
+
+  Point<3> expectedScreenOrigin(-expectedWidth / 2.0, -expectedHeight / 2.0,
+                                1.0);
+  Vector<3> expectedScreenBottomSide(expectedWidth, 0.0, 0.0);
+  Vector<3> expectedScreenLeftSide(0.0, expectedHeight, 0.0);
+
+  assert_rectangle_eq(camera.getScreen(), expectedScreenOrigin,
+                      expectedScreenBottomSide, expectedScreenLeftSide,
+                      EQ_APPROX);
+}

--- a/tests/test_Rectangle.cpp
+++ b/tests/test_Rectangle.cpp
@@ -1,0 +1,198 @@
+#include "../src/Math/Point.hpp"
+#include "../src/Math/Rectangle.hpp"
+#include "../src/Math/Vector.hpp"
+#include "../src/Utility/Clamped.hpp"
+#include <array>
+#include <cmath>
+#include <criterion/criterion.h>
+
+using Raytracer::Math::Point;
+using Raytracer::Math::Rectangle;
+using Raytracer::Math::Rectangle3D;
+using Raytracer::Math::Vector;
+using Raytracer::Utility::Clamped;
+
+static constexpr double EQ_APPROX = 1e-9;
+
+template <std::size_t N>
+void assert_vector_eq(const Vector<N> &v, const std::array<double, N> &ref,
+                      double eps = EQ_APPROX) {
+  for (std::size_t i = 0; i < N; ++i) {
+    cr_assert_float_eq(v.m_components[i], ref[i], eps,
+                       "Vector component[%zu]: expected %g but got %g", i,
+                       ref[i], v.m_components[i]);
+  }
+}
+
+template <std::size_t N>
+void assert_point_eq(const Point<N> &p, const std::array<double, N> &ref,
+                     double eps = EQ_APPROX) {
+  for (std::size_t i = 0; i < N; ++i) {
+    cr_assert_float_eq(p.m_components[i], ref[i], eps,
+                       "Point component[%zu]: expected %g but got %g", i,
+                       ref[i], p.m_components[i]);
+  }
+}
+
+Test(RectangleSuite, DefaultConstructor) {
+  Rectangle<3> rectangle;
+
+  assert_point_eq(rectangle.getOrigin(), {0.0, 0.0, 0.0});
+  assert_vector_eq(rectangle.getBottomSide(), {0.0, 0.0, 0.0});
+  assert_vector_eq(rectangle.getLeftSide(), {0.0, 0.0, 0.0});
+}
+
+Test(RectangleSuite, ParameterizedConstructorAndGetters) {
+  Point<3> origin(1.0, 2.0, 3.0);
+  Vector<3> bottom(3.0, 0.0, 0.0);
+  Vector<3> left(1.0, 0.0, 0.0);
+  Rectangle<3> rectangle(origin, bottom, left);
+
+  assert_point_eq(rectangle.getOrigin(), {1.0, 2.0, 3.0});
+  assert_vector_eq(rectangle.getBottomSide(), {3.0, 0.0, 0.0});
+  assert_vector_eq(rectangle.getLeftSide(), {1.0, 0.0, 0.0});
+}
+
+Test(RectangleSuite, Setters) {
+  Rectangle<3> rectangle;
+
+  Point<3> newOrigin(-1.0, -1.0, -1.0);
+  Vector<3> newBottom(1.0, 0.0, 0.0);
+  Vector<3> newLeft(0.0, 1.0, 0.0);
+
+  rectangle.setOrigin(newOrigin);
+  rectangle.setBottomSide(newBottom);
+  rectangle.setLeftSide(newLeft);
+
+  assert_point_eq(rectangle.getOrigin(), {-1.0, -1.0, -1.0});
+  assert_vector_eq(rectangle.getBottomSide(), {1.0, 0.0, 0.0});
+  assert_vector_eq(rectangle.getLeftSide(), {0.0, 1.0, 0.0});
+}
+
+Test(Rectangle3DSuite, DefaultConstructor) {
+  Rectangle3D rectangle;
+
+  assert_point_eq(rectangle.getOrigin(), {0.0, 0.0, 0.0});
+  assert_vector_eq(rectangle.getBottomSide(), {0.0, 0.0, 0.0});
+  assert_vector_eq(rectangle.getLeftSide(), {0.0, 0.0, 0.0});
+}
+
+Test(Rectangle3DSuite, ParameterizedConstructor) {
+  Point<3> origin(1.0, 2.0, 3.0);
+  Vector<3> bottom(4.0, 0.0, 0.0);
+  Vector<3> left(0.0, 5.0, 0.0);
+  Rectangle3D rectangle(origin, bottom, left);
+
+  assert_point_eq(rectangle.getOrigin(), {1.0, 2.0, 3.0});
+  assert_vector_eq(rectangle.getBottomSide(), {4.0, 0.0, 0.0});
+  assert_vector_eq(rectangle.getLeftSide(), {0.0, 5.0, 0.0});
+}
+
+Test(Rectangle3DSuite, PointAt) {
+  Point<3> origin(1.0, 1.0, 1.0);
+  Vector<3> bottom(2.0, 0.0, 0.0);
+  Vector<3> left(0.0, 3.0, 0.0);
+  Rectangle3D rectangle(origin, bottom, left);
+
+  assert_point_eq(rectangle.pointAt(Clamped<double, 0.0, 1.0>(0.0),
+                                    Clamped<double, 0.0, 1.0>(0.0)),
+                  {1.0, 1.0, 1.0});
+  assert_point_eq(rectangle.pointAt(Clamped<double, 0.0, 1.0>(1.0),
+                                    Clamped<double, 0.0, 1.0>(0.0)),
+                  {3.0, 1.0, 1.0});
+  assert_point_eq(rectangle.pointAt(Clamped<double, 0.0, 1.0>(0.0),
+                                    Clamped<double, 0.0, 1.0>(1.0)),
+                  {1.0, 4.0, 1.0});
+  assert_point_eq(rectangle.pointAt(Clamped<double, 0.0, 1.0>(1.0),
+                                    Clamped<double, 0.0, 1.0>(1.0)),
+                  {3.0, 4.0, 1.0});
+  assert_point_eq(rectangle.pointAt(Clamped<double, 0.0, 1.0>(0.5),
+                                    Clamped<double, 0.0, 1.0>(0.5)),
+                  {2.0, 2.5, 1.0});
+}
+
+Test(Rectangle3DSuite, GetNormal) {
+  Point<3> origin(0.0, 0.0, 0.0);
+  Vector<3> bottom(2.0, 0.0, 0.0);
+  Vector<3> left(0.0, 3.0, 0.0);
+  Rectangle3D rectangleXY(origin, bottom, left);
+
+  assert_vector_eq(rectangleXY.getNormal(), {0.0, 0.0, 1.0});
+
+  Vector<3> bottomZ(0.0, 0.0, 4.0);
+  Vector<3> leftY(0.0, -5.0, 0.0);
+  Rectangle3D rectangleZY(origin, bottomZ, leftY);
+
+  assert_vector_eq(rectangleZY.getNormal(), {1.0, 0.0, 0.0});
+
+  Vector<3> bottomDiag(1.0, 1.0, 0.0);
+  Vector<3> leftDiag(0.0, 1.0, 1.0);
+  Rectangle3D rectangleDiag(origin, bottomDiag, leftDiag);
+
+  double len = std::sqrt(1.0 + 1.0 + 1.0);
+  assert_vector_eq(rectangleDiag.getNormal(),
+                   {1.0 / len, -1.0 / len, 1.0 / len});
+}
+
+Test(Rectangle3DSuite, GetArea) {
+  Point<3> origin(0.0, 0.0, 0.0);
+  Vector<3> bottom(2.0, 0.0, 0.0);
+  Vector<3> left(0.0, 3.0, 0.0);
+  Rectangle3D rectangleOrtho(origin, bottom, left);
+
+  cr_assert_float_eq(rectangleOrtho.getArea(), 6.0, EQ_APPROX);
+
+  Vector<3> bottomDiag(3.0, 0.0, 0.0);
+  Vector<3> leftDiag(1.0, 1.0, 0.0);
+  Rectangle3D rectangleNonOrtho(origin, bottomDiag, leftDiag);
+
+  cr_assert_float_eq(rectangleNonOrtho.getArea(), 3.0, EQ_APPROX);
+}
+
+Test(Rectangle3DSuite, Contains) {
+  Point<3> origin(1.0, 2.0, 3.0);
+  Vector<3> bottom(4.0, 0.0, 0.0);
+  Vector<3> left(0.0, 6.0, 0.0);
+  Rectangle3D rectangle(origin, bottom, left);
+
+  cr_assert(rectangle.contains(Point<3>(1.0, 2.0, 3.0)),
+            "Origin should be inside");
+  cr_assert(rectangle.contains(Point<3>(5.0, 2.0, 3.0)),
+            "End of bottom side should be inside");
+  cr_assert(rectangle.contains(Point<3>(1.0, 8.0, 3.0)),
+            "End of left side should be inside");
+  cr_assert(rectangle.contains(Point<3>(5.0, 8.0, 3.0)),
+            "Opposite corner should be inside");
+  cr_assert(rectangle.contains(Point<3>(3.0, 5.0, 3.0)),
+            "Center point should be inside");
+
+  cr_assert_not(rectangle.contains(Point<3>(0.9, 2.0, 3.0)),
+                "Point before origin (u<0)");
+  cr_assert_not(rectangle.contains(Point<3>(5.1, 2.0, 3.0)),
+                "Point past bottom side (u>1)");
+  cr_assert_not(rectangle.contains(Point<3>(1.0, 1.9, 3.0)),
+                "Point before origin (v<0)");
+  cr_assert_not(rectangle.contains(Point<3>(1.0, 8.1, 3.0)),
+                "Point past left side (v>1)");
+  cr_assert_not(rectangle.contains(Point<3>(6.0, 9.0, 3.0)),
+                "Point outside both u and v range");
+
+  cr_assert(rectangle.contains(Point<3>(3.0, 5.0, 10.0)),
+            "Center point but off-plane Z");
+  cr_assert_not(rectangle.contains(Point<3>(6.0, 9.0, 10.0)),
+                "Outside point but off-plane Z");
+
+  Point<3> originNonOrtho(0.0, 0.0, 0.0);
+  Vector<3> bottomNonOrtho(1.0, 1.0, 0.0);
+  Vector<3> leftNonOrtho(0.0, 1.0, 1.0);
+  Rectangle3D rectangleNonOrtho(originNonOrtho, bottomNonOrtho, leftNonOrtho);
+
+  cr_assert(rectangleNonOrtho.contains(Point<3>(0.5, 1.0, 0.5)),
+            "Center point (non-orthogonal)");
+
+  cr_assert(rectangleNonOrtho.contains(Point<3>(1.0, 0.0, 0.0)),
+            "Point on edge (non-orthogonal)");
+
+  cr_assert_not(rectangleNonOrtho.contains(Point<3>(-0.1, 0.0, 0.0)),
+                "Point outside u range (non-orthogonal)");
+}


### PR DESCRIPTION
**[DO NOT MERGE NOW!]**
- Still missing a ray method that takes two doubles u and v as arguments that represents a point of the screen (using pointAt). The method will return a ray, going from the camera to the coordinates u and v of the image.